### PR TITLE
Fixing FileInputStream resource leak.

### DIFF
--- a/QuantcastAndroidSdk/src/com/quantcast/measurement/service/QCMeasurement.java
+++ b/QuantcastAndroidSdk/src/com/quantcast/measurement/service/QCMeasurement.java
@@ -353,7 +353,7 @@ enum QCMeasurement implements QCNotificationListener {
                 try {
                     byte buffer[] = new byte[256];
                     fis = context.openFileInput(QC_SESSION_FILE);
-                    int length = context.openFileInput(QC_SESSION_FILE).read(buffer);
+                    int length = fis.read(buffer);
                     m_sessionId = new String(buffer, 0, length);
                 } catch (Exception e) {
                     QCLog.e(TAG, "Error reading session file ", e);


### PR DESCRIPTION
`fis` isn't being referenced. Instead there is another `FileInputStream` opening and reading the file which is causing a resource leak.

Fixing by reading form `fis`, which is closed in the finally scope.
