### PR TITLE
Update Apache HTTP Client to HttpURLConnection

### DIFF
--- a/QuantcastAndroidSdk/AndroidManifest.xml
+++ b/QuantcastAndroidSdk/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
     <application
         android:usesCleartextTraffic="true">
-        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
 
         <activity android:name="com.quantcast.measurement.service.AboutQuantcastScreen"
             android:label="OtherName"/>


### PR DESCRIPTION
Apache HTTP Client support was removed in Android 6.0. It's suggested to use [HttpURLConnection ](https://developer.android.com/reference/java/net/HttpURLConnection)instead.

Ref: https://developer.android.com/about/versions/marshmallow/android-6.0-changes#behavior-apache-http-client

Currently `QCDataUploader` and `QCPolicy` use the old Apache Client. This PR will update it to `HttpURLConnection`